### PR TITLE
Fix RSS feed crash by disabling Antlers parsing on content fields

### DIFF
--- a/resources/blueprints/collections/articles/article.yaml
+++ b/resources/blueprints/collections/articles/article.yaml
@@ -153,7 +153,7 @@ tabs:
                             enable_input_rules: true
                             enable_paste_rules: true
                             remove_empty_nodes: false
-                            antlers: true
+                            antlers: false
                             link_noopener: false
                             link_noreferrer: false
                             always_show_set_button: false
@@ -183,7 +183,7 @@ tabs:
               enable_input_rules: true
               enable_paste_rules: true
               remove_empty_nodes: false
-              antlers: true
+              antlers: false
               always_show_set_button: false
               collapse: false
               previews: true


### PR DESCRIPTION
Statamic 6's stricter Antlers parser interprets @ symbols in article text (e.g. @mijustin) as template directives, breaking the /feed route.